### PR TITLE
Don't put a function inside a function

### DIFF
--- a/ITpings_connector.php
+++ b/ITpings_connector.php
@@ -598,12 +598,13 @@ function create_ITpings_Tables()
 
 //region ===== CREATE ITPINGS DATABASE : VIEWS ====================================================
 
+function echoView($sql)
+{
+    echo "<pre>" . $sql . "</pre>";
+}
+
 function Create_Or_Replace_View($view_name)
 {
-    function echoView($sql)
-    {
-        echo "<pre>" . $sql . "</pre>";
-    }
 
 //    function JOIN($table, $as_1, $as_2, $key)
 //    {


### PR DESCRIPTION
I was getting errors like this:
```
PHP Fatal error:  Cannot redeclare echoView() (previously declared in /var/www/ttn/ITpings/ITpings_connector.php:603) in /var/www/ttn/ITpings/ITpings_connector.php on line 603
```
because Create_Or_Replace_View() is called multiple times. Moving echoView() outside of Create_Or_Replace_View() fixed this issue;